### PR TITLE
Good Evening 

### DIFF
--- a/fixtures/avsc/invalid/invalidType.avsc
+++ b/fixtures/avsc/invalid/invalidType.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "invalid",
+  "name": "InvalidType",
+  "namespace": "com.org.domain.fixtures"
+  "fields": [
+    {
+      "type": "string",
+      "name": "full_name"
+    }
+  ]
+}

--- a/fixtures/avsc/invalid/invalidType.avsc
+++ b/fixtures/avsc/invalid/invalidType.avsc
@@ -1,7 +1,7 @@
 {
   "type": "invalid",
   "name": "InvalidType",
-  "namespace": "com.org.domain.fixtures"
+  "namespace": "com.org.domain.fixtures",
   "fields": [
     {
       "type": "string",

--- a/fixtures/avsc/invalid/missingFields.avsc
+++ b/fixtures/avsc/invalid/missingFields.avsc
@@ -1,0 +1,5 @@
+{
+  "type": "record",
+  "name": "MissingFields",
+  "namespace": "com.org.domain.fixtures"
+}

--- a/fixtures/avsc/invalid/missingName.avsc
+++ b/fixtures/avsc/invalid/missingName.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "namespace": "com.org.domain.fixtures",
+  "fields": [
+    {
+      "type": "string",
+      "name": "full_name"
+    }
+  ]
+}

--- a/fixtures/avsc/invalid/missingType.avsc
+++ b/fixtures/avsc/invalid/missingType.avsc
@@ -1,0 +1,10 @@
+{
+  "name": "MissingType",
+  "namespace": "com.org.domain.fixtures"
+  "fields": [
+    {
+      "type": "string",
+      "name": "full_name"
+    }
+  ]
+}

--- a/fixtures/avsc/invalid/missingType.avsc
+++ b/fixtures/avsc/invalid/missingType.avsc
@@ -1,6 +1,6 @@
 {
   "name": "MissingType",
-  "namespace": "com.org.domain.fixtures"
+  "namespace": "com.org.domain.fixtures",
   "fields": [
     {
       "type": "string",

--- a/fixtures/avsc/non_namespaced.avsc
+++ b/fixtures/avsc/non_namespaced.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "name": "NoNamespacePerson",
+  "fields": [
+    {
+      "type": "string",
+      "name": "full_name"
+    }
+  ]
+}

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -1,9 +1,13 @@
-export interface Schema {
+export interface RawSchema {
+  name: string
+  namespace?: string
+  type: 'record'
+  fields: any[]
+}
+export interface Schema extends RawSchema {
   toBuffer: (payload: object) => Buffer // FIXME:
   fromBuffer: (payload: object) => Buffer // FIXME:
   isValid: (payload: object, opts: { errorHook: (path: any) => void }) => void // FIXME:
-  name: string
-  namespace: string
 }
 
 declare global {

--- a/src/SchemaRegistry.spec.ts
+++ b/src/SchemaRegistry.spec.ts
@@ -32,9 +32,9 @@ describe('SchemaRegistry', () => {
       namespace = `N${uuid().replace(/-/g, '_')}`
       subject = `${namespace}.RandomTest`
       Schema = {
+        namespace,
         type: 'record',
         name: 'RandomTest',
-        namespace: '${namespace}',
         fields: [{ type: 'string', name: 'full_name' }],
       }
     })
@@ -81,10 +81,18 @@ describe('SchemaRegistry', () => {
       )
     })
 
-    it('accepts schema without a namespace', async () => {
+    it('throws an error when schema does not have a namespace', async () => {
       delete Schema.namespace
-      const nonNamespaced = readAVSC('../fixtures/avsc/non_namespaced.avsc')
-      await expect(schemaRegistry.register(nonNamespaced)).resolves.toEqual({
+      await expect(schemaRegistry.register(Schema)).rejects.toHaveProperty(
+        'message',
+        'Invalid namespace: undefined',
+      )
+    })
+
+    it('accepts schema without a namespace when subject is specified', async () => {
+      delete Schema.namespace
+      const nonNamespaced = readAVSC(path.join(__dirname, '../fixtures/avsc/non_namespaced.avsc'))
+      await expect(schemaRegistry.register(nonNamespaced, { subject })).resolves.toEqual({
         id: expect.any(Number),
       })
     })

--- a/src/SchemaRegistry.spec.ts
+++ b/src/SchemaRegistry.spec.ts
@@ -7,6 +7,7 @@ import API from './api'
 import { COMPATIBILITY, DEFAULT_API_CLIENT_ID } from './constants'
 import encodedAnotherPersonV2 from '../fixtures/encodedAnotherPersonV2'
 import wrongMagicByte from '../fixtures/wrongMagicByte'
+import { RawSchema } from './@types'
 
 const REGISTRY_HOST = 'http://localhost:8982'
 const schemaRegistryAPIClientArgs = { host: REGISTRY_HOST }
@@ -24,20 +25,18 @@ describe('SchemaRegistry', () => {
   })
 
   describe('#register', () => {
-    let namespace, Schema, subject, api
+    let namespace, Schema: RawSchema, subject, api
 
     beforeEach(() => {
       api = API(schemaRegistryAPIClientArgs)
       namespace = `N${uuid().replace(/-/g, '_')}`
       subject = `${namespace}.RandomTest`
-      Schema = JSON.parse(`
-        {
-          "type": "record",
-          "name": "RandomTest",
-          "namespace": "${namespace}",
-          "fields": [{ "type": "string", "name": "full_name" }]
-        }
-      `)
+      Schema = {
+        type: 'record',
+        name: 'RandomTest',
+        namespace: '${namespace}',
+        fields: [{ type: 'string', name: 'full_name' }],
+      }
     })
 
     it('uploads the new schema', async () => {
@@ -82,12 +81,12 @@ describe('SchemaRegistry', () => {
       )
     })
 
-    it('throws an error when schema does not have a namespace', async () => {
+    it('accepts schema without a namespace', async () => {
       delete Schema.namespace
-      await expect(schemaRegistry.register(Schema)).rejects.toHaveProperty(
-        'message',
-        'Invalid namespace: undefined',
-      )
+      const nonNamespaced = readAVSC('../fixtures/avsc/non_namespaced.avsc')
+      await expect(schemaRegistry.register(nonNamespaced)).resolves.toEqual({
+        id: expect.any(Number),
+      })
     })
 
     it('throws an error when the configured compatibility is different than defined in the client', async () => {

--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -52,14 +52,14 @@ export default class SchemaRegistry {
       throw new ConfluentSchemaRegistryArgumentError(`Invalid name: ${schema.name}`)
     }
 
-    if (!schema.namespace) {
-      throw new ConfluentSchemaRegistryArgumentError(`Invalid namespace: ${schema.namespace}`)
-    }
-
     let subject: string
     if (userOpts && userOpts.subject) {
       subject = userOpts.subject
     } else {
+      if (!schema.namespace) {
+        throw new ConfluentSchemaRegistryArgumentError(`Invalid namespace: ${schema.namespace}`)
+      }
+
       subject = [schema.namespace, schema.name].join(separator)
     }
 

--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -14,7 +14,7 @@ import {
   ConfluentSchemaRegistryArgumentError,
   ConfluentSchemaRegistryCompatibilityError,
 } from './errors'
-import { Schema } from './@types'
+import { Schema, RawSchema } from './@types'
 
 interface RegisteredSchema {
   id: number
@@ -45,7 +45,7 @@ export default class SchemaRegistry {
     this.cache = new Cache(options?.forSchemaOptions)
   }
 
-  public async register(schema: Schema, userOpts?: Opts): Promise<RegisteredSchema> {
+  public async register(schema: RawSchema, userOpts?: Opts): Promise<RegisteredSchema> {
     const { compatibility, separator } = { ...DEFAULT_OPTS, ...userOpts }
 
     if (!schema.name) {
@@ -103,7 +103,7 @@ export default class SchemaRegistry {
 
     const response = await this.getSchemaOriginRequest(registryId)
     const foundSchema: { schema: string } = response.data()
-    const rawSchema: Schema = JSON.parse(foundSchema.schema)
+    const rawSchema: RawSchema = JSON.parse(foundSchema.schema)
 
     return this.cache.setSchema(registryId, rawSchema)
   }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,6 @@
 import avro, { ForSchemaOptions } from 'avsc'
 
-import { Schema } from './@types'
+import { Schema, RawSchema } from './@types'
 
 export default class Cache {
   registryIdBySubject: { [key: string]: number }
@@ -23,7 +23,7 @@ export default class Cache {
 
   getSchema = (registryId: number): Schema => this.schemasByRegistryId[registryId]
 
-  setSchema = (registryId: number, schema: Schema) => {
+  setSchema = (registryId: number, schema: RawSchema) => {
     // @ts-ignore TODO: Fix typings for Schema...
     this.schemasByRegistryId[registryId] = avro.Type.forSchema(schema, this.forSchemaOptions)
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,9 +7,11 @@ class ConfluentSchemaRegistryError extends Error {
 
 class ConfluentSchemaRegistryArgumentError extends ConfluentSchemaRegistryError {}
 class ConfluentSchemaRegistryCompatibilityError extends ConfluentSchemaRegistryError {}
+class ConfluentSchemaRegistryInvalidSchemaError extends ConfluentSchemaRegistryError {}
 
 export {
   ConfluentSchemaRegistryError,
   ConfluentSchemaRegistryArgumentError,
   ConfluentSchemaRegistryCompatibilityError,
+  ConfluentSchemaRegistryInvalidSchemaError,
 }

--- a/src/utils/readAVSC.spec.ts
+++ b/src/utils/readAVSC.spec.ts
@@ -1,0 +1,23 @@
+import path from 'path'
+
+import { readAVSC, readAVSCAsync } from './readAVSC'
+import { ConfluentSchemaRegistryInvalidSchemaError } from '../errors'
+
+describe('readAVSC', () => {
+  it('throws an exception for invalid schema definitions', () => {
+    const invalidSchemaFiles = ['invalidType', 'missingFields', 'missingName', 'missingType']
+    invalidSchemaFiles.forEach(schemaName => {
+      expect(() =>
+        readAVSC(path.join(__dirname, `../../fixtures/avsc/invalid/${schemaName}.avsc`)),
+      ).toThrow(ConfluentSchemaRegistryInvalidSchemaError)
+    })
+  })
+})
+
+describe('readAVSCAsync', () => {
+  it('returns a validated schema asynchronously', async () => {
+    return expect(
+      readAVSCAsync(path.join(__dirname, `../../fixtures/avsc/person.avsc`)),
+    ).resolves.toHaveProperty('name', 'Person')
+  })
+})

--- a/src/utils/readAVSC.spec.ts
+++ b/src/utils/readAVSC.spec.ts
@@ -4,9 +4,9 @@ import { readAVSC, readAVSCAsync } from './readAVSC'
 import { ConfluentSchemaRegistryInvalidSchemaError } from '../errors'
 
 describe('readAVSC', () => {
-  it('throws an exception for invalid schema definitions', () => {
-    const invalidSchemaFiles = ['invalidType', 'missingFields', 'missingName', 'missingType']
-    invalidSchemaFiles.forEach(schemaName => {
+  const invalidSchemaFiles = ['invalidType', 'missingFields', 'missingName', 'missingType']
+  invalidSchemaFiles.forEach(schemaName => {
+    it(`throws an exception for invalid schema definitions - ${schemaName}`, () => {
       expect(() =>
         readAVSC(path.join(__dirname, `../../fixtures/avsc/invalid/${schemaName}.avsc`)),
       ).toThrow(ConfluentSchemaRegistryInvalidSchemaError)

--- a/src/utils/readAVSC.ts
+++ b/src/utils/readAVSC.ts
@@ -1,14 +1,36 @@
 import fs from 'fs'
 import { promisify } from 'util'
 
+import { RawSchema } from '../@types'
+import { ConfluentSchemaRegistryInvalidSchemaError } from '../errors'
+
 const readFileAsync = promisify(fs.readFile)
 const ENCODING = 'utf-8'
 
-export function readAVSC(path: string) {
-  return JSON.parse(fs.readFileSync(path, ENCODING))
+function isValidSchema(rawSchema: any): rawSchema is RawSchema {
+  return (
+    'name' in rawSchema &&
+    'type' in rawSchema &&
+    rawSchema.type === 'record' &&
+    'fields' in rawSchema
+  )
 }
 
-export async function readAVSCAsync(path: string) {
-  const file = await readFileAsync(path, ENCODING)
-  return JSON.parse(file)
+function validatedSchema(path: string, rawSchema: any): RawSchema {
+  if (!isValidSchema(rawSchema)) {
+    throw new ConfluentSchemaRegistryInvalidSchemaError(
+      `${path} is not recognized as a valid AVSC file (expecting top level name, type and fields attributes)`,
+    )
+  }
+  return rawSchema
+}
+
+export function readAVSC(path: string): RawSchema {
+  const rawSchema = JSON.parse(fs.readFileSync(path, ENCODING))
+  return validatedSchema(path, rawSchema)
+}
+
+export async function readAVSCAsync(path: string): Promise<RawSchema> {
+  const rawSchema = JSON.parse(await readFileAsync(path, ENCODING))
+  return validatedSchema(path, rawSchema)
 }

--- a/src/utils/readAVSC.ts
+++ b/src/utils/readAVSC.ts
@@ -19,7 +19,7 @@ function isValidSchema(rawSchema: any): rawSchema is RawSchema {
 function validatedSchema(path: string, rawSchema: any): RawSchema {
   if (!isValidSchema(rawSchema)) {
     throw new ConfluentSchemaRegistryInvalidSchemaError(
-      `${path} is not recognized as a valid AVSC file (expecting top level name, type and fields attributes)`,
+      `${path} is not recognized as a valid AVSC file (expecting valid top-level name, type and fields attributes)`,
     )
   }
   return rawSchema


### PR DESCRIPTION
If a `subject` is specified when registering a new schema, the
`namespace` is not used at all and since the schema registry itself
doesn't require a namespace, it seems appropriate that this library
shouldn't require it either.